### PR TITLE
Changed board namespace to avoid collision with 3rd party board definitions...

### DIFF
--- a/pocuter_arduino.json
+++ b/pocuter_arduino.json
@@ -1,7 +1,7 @@
 {
   "packages": [
     {
-      "name": "esp32",
+      "name": "pocuter",
       "maintainer": "Pocuter GmbH",
       "websiteURL": "https://www.pocuter.com",
       "email": "info@pocuter.com",
@@ -10,7 +10,7 @@
       },
       "platforms": [
         {
-          "name": "esp32",
+          "name": "pocuter",
           "architecture": "esp32",
           "version": "2.0.3-RC1",
           "category": "ESP32",
@@ -24,49 +24,49 @@
           "boards": [
            
             {
-              "name": "Pocuter"
+              "name": "Pocuter One"
             }
           ],
           "toolsDependencies": [
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "riscv32-esp-elf-gcc",
               "version": "gcc8_4_0-esp-2021r2-patch3"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "xtensa-esp32-elf-gcc",
               "version": "gcc8_4_0-esp-2021r2-patch3"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "xtensa-esp32s2-elf-gcc",
               "version": "gcc8_4_0-esp-2021r2-patch3"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "xtensa-esp32s3-elf-gcc",
               "version": "gcc8_4_0-esp-2021r2-patch3"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "esptool_py",
               "version": "3.3.0"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "mkspiffs",
               "version": "0.2.3"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "mklittlefs",
               "version": "3.0.0-gnu12-dc7f933"
             }
           ]
         },
 		{
-          "name": "esp32",
+          "name": "pocuter",
           "architecture": "esp32",
           "version": "2.0.3-RC1-PC1.1",
           "category": "ESP32",
@@ -80,49 +80,49 @@
           "boards": [
            
             {
-              "name": "Pocuter"
+              "name": "Pocuter One"
             }
           ],
           "toolsDependencies": [
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "riscv32-esp-elf-gcc",
               "version": "gcc8_4_0-esp-2021r2-patch3"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "xtensa-esp32-elf-gcc",
               "version": "gcc8_4_0-esp-2021r2-patch3"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "xtensa-esp32s2-elf-gcc",
               "version": "gcc8_4_0-esp-2021r2-patch3"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "xtensa-esp32s3-elf-gcc",
               "version": "gcc8_4_0-esp-2021r2-patch3"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "esptool_py",
               "version": "3.3.0"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "mkspiffs",
               "version": "0.2.3"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "mklittlefs",
               "version": "3.0.0-gnu12-dc7f933"
             }
           ]
         },
 		{
-          "name": "esp32",
+          "name": "pocuter",
           "architecture": "esp32",
           "version": "2.0.3-RC1-PC1.2",
           "category": "ESP32",
@@ -136,49 +136,49 @@
           "boards": [
            
             {
-              "name": "Pocuter"
+              "name": "Pocuter One"
             }
           ],
           "toolsDependencies": [
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "riscv32-esp-elf-gcc",
               "version": "gcc8_4_0-esp-2021r2-patch3"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "xtensa-esp32-elf-gcc",
               "version": "gcc8_4_0-esp-2021r2-patch3"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "xtensa-esp32s2-elf-gcc",
               "version": "gcc8_4_0-esp-2021r2-patch3"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "xtensa-esp32s3-elf-gcc",
               "version": "gcc8_4_0-esp-2021r2-patch3"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "esptool_py",
               "version": "3.3.0"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "mkspiffs",
               "version": "0.2.3"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "mklittlefs",
               "version": "3.0.0-gnu12-dc7f933"
             }
           ]
         },
 		  {
-          "name": "esp32",
+          "name": "pocuter",
           "architecture": "esp32",
           "version": "2.0.5-RC1-PC1.3",
           "category": "ESP32",
@@ -192,101 +192,42 @@
           "boards": [
            
             {
-              "name": "Pocuter"
+              "name": "Pocuter One"
             }
           ],
           "toolsDependencies": [
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "riscv32-esp-elf-gcc",
               "version": "gcc8_4_0-esp-2021r2-patch3"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "xtensa-esp32-elf-gcc",
               "version": "gcc8_4_0-esp-2021r2-patch3"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "xtensa-esp32s2-elf-gcc",
               "version": "gcc8_4_0-esp-2021r2-patch3"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "xtensa-esp32s3-elf-gcc",
               "version": "gcc8_4_0-esp-2021r2-patch3"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "esptool_py",
               "version": "3.3.0"
             },
             {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "mkspiffs",
               "version": "0.2.3"
             },
             {
-              "packager": "esp32",
-              "name": "mklittlefs",
-              "version": "3.0.0-gnu12-dc7f933"
-            }
-          ]
-        },
-		  {
-          "name": "esp32",
-          "architecture": "esp32",
-          "version": "2.0.7-RC1-PC1.4",
-          "category": "ESP32",
-          "url": "https://github.com/pocuter/ArduinoBoard/raw/main/pocuter1.4-2.0.7-RC1.zip",
-          "archiveFileName": "pocuter1.4-2.0.7-RC1.zip",
-          "checksum": "SHA-256:D5E97660C7A76F20C2DC8373846A401E84D4A1F62895B49718D08ABE21D78A35",
-          "size": "82544480",
-          "help": {
-            "online": ""
-          },
-          "boards": [
-           
-            {
-              "name": "Pocuter"
-            },
-			{
-              "name": "PocketStar 2"
-            }
-          ],
-          "toolsDependencies": [
-            {
-              "packager": "esp32",
-              "name": "riscv32-esp-elf-gcc",
-              "version": "gcc8_4_0-esp-2021r2-patch3"
-            },
-            {
-              "packager": "esp32",
-              "name": "xtensa-esp32-elf-gcc",
-              "version": "gcc8_4_0-esp-2021r2-patch3"
-            },
-            {
-              "packager": "esp32",
-              "name": "xtensa-esp32s2-elf-gcc",
-              "version": "gcc8_4_0-esp-2021r2-patch3"
-            },
-            {
-              "packager": "esp32",
-              "name": "xtensa-esp32s3-elf-gcc",
-              "version": "gcc8_4_0-esp-2021r2-patch3"
-            },
-            {
-              "packager": "esp32",
-              "name": "esptool_py",
-              "version": "3.3.0"
-            },
-            {
-              "packager": "esp32",
-              "name": "mkspiffs",
-              "version": "0.2.3"
-            },
-            {
-              "packager": "esp32",
+              "packager": "pocuter",
               "name": "mklittlefs",
               "version": "3.0.0-gnu12-dc7f933"
             }


### PR DESCRIPTION
Changed board namespace to avoid collision with 3rd party board definitions
Removed 2.0.7-RC1-PC1.4 as it breaks compilation on the Pocuter One